### PR TITLE
WIP: Honor maximum requested stack depth

### DIFF
--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -15,6 +15,7 @@
 #include <boost/core/explicit_operator_bool.hpp>
 #include <boost/container_hash/hash_fwd.hpp>
 
+#include <algorithm>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -72,7 +73,7 @@ class basic_stacktrace {
         try {
             {   // Fast path without additional allocations
                 native_frame_ptr_t buffer[buffer_size];
-                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, buffer_size, frames_to_skip + 1);
+                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, std::min(buffer_size, max_depth), frames_to_skip + 1);
                 if (buffer_size > frames_count || frames_count >= max_depth) {
                     const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
                     fill(buffer, size);


### PR DESCRIPTION
Regardless of any user provided maximum stack depth `boost::stacktrace::basic_stacktrace<>::init` will try to obtain 128 stack frames.

For older Microsoft platforms like Windows Server 2003 and Windows XP this is problematic as `RtlCaptureStackBacktrace` has a stricter [limit](https://msdn.microsoft.com/de-de/library/windows/desktop/bb204633(v=vs.85).aspx) on the stack depth.
